### PR TITLE
perf(blogs): improve line reveal

### DIFF
--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -27,7 +27,13 @@ declare global {
   const blogChromeInitial: typeof import('./src/utils/blog-layout').blogChromeInitial
   const blogContentAnimate: typeof import('./src/utils/blog-layout').blogContentAnimate
   const blogLineRevealBaseDelay: typeof import('./src/utils/blog-layout').blogLineRevealBaseDelay
+  const blogLineRevealBaseDelayMs: typeof import('./src/utils/blog-layout').blogLineRevealBaseDelayMs
+  const blogLineRevealDuration: typeof import('./src/utils/blog-layout').blogLineRevealDuration
+  const blogLineRevealDurationMs: typeof import('./src/utils/blog-layout').blogLineRevealDurationMs
+  const blogLineRevealMaxIndex: typeof import('./src/utils/blog-layout').blogLineRevealMaxIndex
   const blogLineRevealStagger: typeof import('./src/utils/blog-layout').blogLineRevealStagger
+  const blogLineRevealStaggerMs: typeof import('./src/utils/blog-layout').blogLineRevealStaggerMs
+  const blogLineRevealTotalMs: typeof import('./src/utils/blog-layout').blogLineRevealTotalMs
   const blogMetaLayoutId: typeof import('./src/utils/blog-layout').blogMetaLayoutId
   const blogSharedElementExit: typeof import('./src/utils/blog-layout').blogSharedElementExit
   const blogTagEnter: typeof import('./src/utils/blog-layout').blogTagEnter
@@ -67,7 +73,6 @@ declare global {
   const getCurrentScope: typeof import('vue').getCurrentScope
   const getCurrentWatcher: typeof import('vue').getCurrentWatcher
   const h: typeof import('vue').h
-  const htmlToMarkdownBlocks: typeof import('./src/utils/markdown-blocks').htmlToMarkdownBlocks
   const ignorableWatch: typeof import('@vueuse/core').ignorableWatch
   const inject: typeof import('vue').inject
   const injectLocal: typeof import('@vueuse/core').injectLocal
@@ -362,7 +367,13 @@ declare module 'vue' {
     readonly blogChromeExit: UnwrapRef<typeof import('./src/utils/blog-layout')['blogChromeExit']>
     readonly blogChromeInitial: UnwrapRef<typeof import('./src/utils/blog-layout')['blogChromeInitial']>
     readonly blogLineRevealBaseDelay: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealBaseDelay']>
+    readonly blogLineRevealBaseDelayMs: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealBaseDelayMs']>
+    readonly blogLineRevealDuration: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealDuration']>
+    readonly blogLineRevealDurationMs: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealDurationMs']>
+    readonly blogLineRevealMaxIndex: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealMaxIndex']>
     readonly blogLineRevealStagger: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealStagger']>
+    readonly blogLineRevealStaggerMs: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealStaggerMs']>
+    readonly blogLineRevealTotalMs: UnwrapRef<typeof import('./src/utils/blog-layout')['blogLineRevealTotalMs']>
     readonly blogMetaLayoutId: UnwrapRef<typeof import('./src/utils/blog-layout')['blogMetaLayoutId']>
     readonly blogSharedElementExit: UnwrapRef<typeof import('./src/utils/blog-layout')['blogSharedElementExit']>
     readonly blogTagEnter: UnwrapRef<typeof import('./src/utils/blog-layout')['blogTagEnter']>
@@ -381,7 +392,6 @@ declare module 'vue' {
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
     readonly getCurrentWatcher: UnwrapRef<typeof import('vue')['getCurrentWatcher']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
-    readonly htmlToMarkdownBlocks: UnwrapRef<typeof import('./src/utils/markdown-blocks')['htmlToMarkdownBlocks']>
     readonly inject: UnwrapRef<typeof import('vue')['inject']>
     readonly isProxy: UnwrapRef<typeof import('vue')['isProxy']>
     readonly isReactive: UnwrapRef<typeof import('vue')['isReactive']>

--- a/src/components/BlogContent.vue
+++ b/src/components/BlogContent.vue
@@ -5,6 +5,8 @@ const { url } = defineProps<{
   url: string;
 }>();
 
+const emit = defineEmits<{ revealed: [] }>();
+
 const { data: downloaded, isFetching } = useFetch<{
   matter: Blog;
   content: string;
@@ -26,5 +28,5 @@ const content = computed(() => downloaded.value?.content ?? '');
 
 <template>
   <AppLoader v-if="isFetching" />
-  <Markdown v-else :key="url" :src-base-url :content />
+  <Markdown v-else :key="url" :src-base-url :content @revealed="emit('revealed')" />
 </template>

--- a/src/components/BlogPage.vue
+++ b/src/components/BlogPage.vue
@@ -15,16 +15,25 @@ const related = computed(() => relatedBlogs(blog, blogs));
 const readNextLabel = computed(() =>
   related.value.similar ? 'Read something similar' : 'Keep reading',
 );
+
+// Hold the related list back until the article body has finished revealing.
+const contentRevealed = ref(false);
+watch(
+  () => blog.url,
+  () => {
+    contentRevealed.value = false;
+  },
+);
 </script>
 
 <template>
   <div>
     <BlogTitle v-bind="blog" />
     <motion.div :exit="blogChromeExit">
-      <BlogContent :url="blog.url" />
+      <BlogContent :url="blog.url" @revealed="contentRevealed = true" />
     </motion.div>
     <motion.div
-      v-if="related.blogs.length"
+      v-if="related.blogs.length && contentRevealed"
       :initial="blogChromeInitial"
       :animate="blogChromeAnimate"
       :exit="blogChromeExit"

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -1,18 +1,32 @@
 <script setup lang="ts">
 import { useMarkDown } from '~/composables/use-markdown';
-import { htmlToMarkdownBlocks } from '~/utils/markdown-blocks';
 import { applyMarkdownLineReveal } from '~/utils/markdown-line-reveal';
-import { blogLineRevealBaseDelay, blogLineRevealStagger } from '~/utils/blog-layout';
+import {
+  blogLineRevealBaseDelay,
+  blogLineRevealStagger,
+  blogLineRevealDuration,
+  blogLineRevealTotalMs,
+} from '~/utils/blog-layout';
 
 const { content, srcBaseUrl } = defineProps<{
   content: string;
   srcBaseUrl: string;
 }>();
 
+/** Fires once the last line has finished revealing (or immediately when there's
+    nothing to animate) so downstream chrome can wait for the body. */
+const emit = defineEmits<{ revealed: [] }>();
+
 const md = useMarkDown();
 const articleRef = ref<HTMLElement | null>(null);
 const prefersReducedMotion = usePreferredReducedMotion();
-const revealed = ref(false);
+// Article stays hidden until words are wrapped and lines measured — otherwise
+// the full text flashes before it splits and hides for the reveal.
+const ready = ref(false);
+// True only once the line split has run (and markers injected) — gates the
+// native-marker suppression so reduced-motion/empty renders keep their bullets.
+const split = ref(false);
+let revealTimer: ReturnType<typeof setTimeout> | undefined;
 
 const render = computed(() => {
   const html = md.render(content ?? '');
@@ -22,55 +36,65 @@ const render = computed(() => {
   });
 });
 
-const blocks = computed(() => htmlToMarkdownBlocks(render.value));
-
 function waitForPaint() {
   return new Promise<void>((resolve) => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
   });
 }
 
-async function revealLines() {
-  revealed.value = false;
+async function reveal() {
+  ready.value = false;
+  split.value = false;
+  const article = articleRef.value;
+
+  if (!article?.childElementCount || prefersReducedMotion.value === 'reduce') {
+    ready.value = true;
+    emit('revealed');
+    return;
+  }
+
+  // Line wrapping depends on font metrics, so measure once fonts have settled.
+  if (document.fonts?.ready) {
+    await document.fonts.ready.catch(() => {});
+  }
   await nextTick();
   await waitForPaint();
 
-  const article = articleRef.value;
-  if (!article) {
+  // The component may have unmounted while awaiting (navigation).
+  if (articleRef.value !== article) {
     return;
   }
 
-  if (!blocks.value.length) {
-    revealed.value = true;
-    return;
-  }
+  const lineCount = applyMarkdownLineReveal(article);
+  split.value = true;
+  ready.value = true;
 
-  if (prefersReducedMotion.value === 'reduce') {
-    revealed.value = true;
-    return;
-  }
-
-  applyMarkdownLineReveal(article);
-  revealed.value = true;
+  // Signal completion off a deterministic timer rather than `animationend`, which
+  // can silently never fire (cancelled animation, inactive tab, no rendered box).
+  revealTimer = setTimeout(() => emit('revealed'), blogLineRevealTotalMs(lineCount));
 }
 
-watch(() => content, revealLines);
+onMounted(reveal);
 
-onMounted(revealLines);
+onBeforeUnmount(() => {
+  clearTimeout(revealTimer);
+});
 </script>
 
 <template>
+  <!-- key on content so navigating between posts replays the reveal -->
   <article
     ref="articleRef"
+    :key="content"
     class="prose dark:prose-invert prose-p:text-gray-500/80 prose-p:dark:text-gray-100/80 lg:prose-lg md-lines"
-    :class="{ 'md-lines-revealed': revealed }"
+    :class="{ 'md-lines-ready': ready, 'md-lines-split': split }"
     :style="{
       '--line-base-delay': blogLineRevealBaseDelay,
       '--line-stagger': blogLineRevealStagger,
+      '--line-duration': blogLineRevealDuration,
     }"
-  >
-    <div v-for="(block, index) in blocks" :key="index" class="md-block" v-html="block" />
-  </article>
+    v-html="render"
+  />
 </template>
 
 <style lang="css">
@@ -117,77 +141,64 @@ li code {
   word-break: normal;
 }
 
-.md-lines:not(.md-lines-revealed) {
+/*
+ * Per-visual-line reveal. A JS pass (markdown-line-reveal) wraps each word in a
+ * .md-word span in place — inline markup is untouched — and tags each word with
+ * a --line-index for its wrapped line. Blocks that aren't split into lines
+ * (code, images, tables) get .md-reveal and animate as one unit. Both share the
+ * same fade/slide keyed off --line-index. The article is hidden until the split
+ * runs so the un-split text never flashes.
+ */
+.md-lines:not(.md-lines-ready) {
   visibility: hidden;
 }
 
-.md-lines.md-lines-revealed {
-  visibility: visible;
+.md-word,
+.md-reveal {
+  opacity: 0;
+  transform: translateY(0.5em);
+  animation: md-line-in var(--line-duration, 0.42s) cubic-bezier(0.33, 1, 0.68, 1) both;
+  animation-delay: calc(var(--line-base-delay, 0.2s) + var(--line-index, 0) * var(--line-stagger, 90ms));
 }
 
-/* Native markers paint before line text; bullets live inside the animated inner */
-.md-lines :is(ul, ol) {
-  list-style: none !important;
-  padding-inline-start: 1.625em;
+/* Words must be inline-block for translateY; long words still wrap. */
+.md-word {
+  display: inline-block;
+  overflow-wrap: anywhere;
 }
 
-.md-lines ul > li > .md-line:first-child > .md-line__inner::before {
-  content: '•\00a0';
+/*
+ * Native list markers paint immediately and can't fade (opacity isn't allowed on
+ * ::marker), so drop them and draw our own on the injected .md-marker token,
+ * which reveals with the item's first line.
+ */
+.md-lines-split :is(ul, ol) {
+  list-style: none;
 }
 
-.md-lines ul ul > li > .md-line:first-child > .md-line__inner::before {
-  content: '◦\00a0';
-}
-
-.md-lines ol {
+.md-lines-split ol {
   counter-reset: md-ol;
 }
 
-.md-lines ol > li {
+.md-lines-split ol > li {
   counter-increment: md-ol;
 }
 
-.md-lines ol > li > .md-line:first-child > .md-line__inner::before {
-  content: counter(md-ol) '.\00a0';
+.md-marker {
+  margin-right: 0.4em;
+  overflow-wrap: normal;
 }
 
-.md-line {
-  display: block;
-  overflow: hidden;
+.md-lines-split ul > li > .md-marker::before {
+  content: '•';
 }
 
-.md-line__inner {
-  display: block;
-  opacity: 0;
-  transform: translateY(0.92em);
-  animation: md-line-in 0.52s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-  animation-delay: calc(var(--line-base-delay, 0.2s) + var(--line-index, 0) * var(--line-stagger, 38ms));
-  will-change: transform, opacity;
+.md-lines-split ul ul > li > .md-marker::before {
+  content: '◦';
 }
 
-/* Shiki/pre chrome lives on the animated inner wrapper, not the shell */
-.md-lines pre.md-line-reveal-host,
-.md-lines pre.md-line-reveal-host.shiki {
-  padding: 0;
-  background: transparent !important;
-  background-color: transparent !important;
-}
-
-.md-lines pre.md-line-reveal-host code,
-.md-lines pre.md-line-reveal-host .shiki {
-  background: transparent !important;
-  background-color: transparent !important;
-}
-
-.md-lines pre.md-line-reveal-host .md-line__inner {
-  padding: 1em;
-  overflow-x: auto;
-  border-radius: 0.375rem;
-  background-color: #fafafa !important;
-}
-
-.dark .md-lines pre.md-line-reveal-host .md-line__inner {
-  background-color: #0e0e0e !important;
+.md-lines-split ol > li > .md-marker::before {
+  content: counter(md-ol) '.';
 }
 
 @keyframes md-line-in {
@@ -198,11 +209,12 @@ li code {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .md-lines:not(.md-lines-revealed) {
+  .md-lines {
     visibility: visible;
   }
 
-  .md-line__inner {
+  .md-word,
+  .md-reveal {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/utils/blog-layout.ts
+++ b/src/utils/blog-layout.ts
@@ -57,7 +57,30 @@ export const blogChromeExit = {
   transition: { duration: 0.12 },
 } as const;
 
-/** Stagger start for article lines — after the title/meta layout animation. */
-export const blogLineRevealBaseDelay = '0.2s';
+/* Article line-reveal timing (ms). Single source of truth — the CSS pulls these
+   in as custom properties, and Markdown derives the total reveal duration from
+   them so downstream chrome can wait without relying on animation events. */
 
-export const blogLineRevealStagger = '38ms';
+/** Stagger start for article lines — after the title/meta layout animation. */
+export const blogLineRevealBaseDelayMs = 200;
+
+/** Gap between consecutive block reveals. */
+export const blogLineRevealStaggerMs = 90;
+
+/** Per-block fade/slide duration. Kept short so blocks snap in crisply rather
+    than drifting — the deliberate pacing comes from the stagger, not this. */
+export const blogLineRevealDurationMs = 420;
+
+/** Lines past this position share the final delay, so long posts don't accrue an
+    ever-growing reveal (and the related list doesn't wait forever). */
+export const blogLineRevealMaxIndex = 12;
+
+export const blogLineRevealBaseDelay = `${blogLineRevealBaseDelayMs}ms`;
+export const blogLineRevealStagger = `${blogLineRevealStaggerMs}ms`;
+export const blogLineRevealDuration = `${blogLineRevealDurationMs}ms`;
+
+/** Total time from mount until the last line has finished revealing. */
+export function blogLineRevealTotalMs(lineCount: number) {
+  const lastIndex = Math.min(Math.max(lineCount - 1, 0), blogLineRevealMaxIndex);
+  return blogLineRevealBaseDelayMs + lastIndex * blogLineRevealStaggerMs + blogLineRevealDurationMs;
+}

--- a/src/utils/markdown-blocks.ts
+++ b/src/utils/markdown-blocks.ts
@@ -1,9 +1,0 @@
-/** Split rendered markdown HTML into top-level block elements. */
-export function htmlToMarkdownBlocks(html: string): string[] {
-  if (!html.trim()) {
-    return [];
-  }
-
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  return Array.from(doc.body.children).map((node) => node.outerHTML);
-}

--- a/src/utils/markdown-line-reveal.ts
+++ b/src/utils/markdown-line-reveal.ts
@@ -1,141 +1,190 @@
-const LINE_BLOCK_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, blockquote, li, pre';
+import { blogLineRevealMaxIndex } from '~/utils/blog-layout';
 
-/** Keeps pre/shiki chrome in sync with the line reveal delay. */
-function tagRevealHost(element: HTMLElement) {
-  if (element.tagName !== 'PRE') {
+/*
+ * True per-visual-line reveal that preserves inline markup.
+ *
+ * The trick: we never build "line container" elements (which would force an
+ * inline element like a link to be split across two containers, and previously
+ * led to flattening the block via textContent). Instead we wrap each *word* in
+ * a span in place — leaving <a>/<code>/<strong> structure untouched — then read
+ * each word's visual line from its layout position and hand every word a
+ * per-line stagger via --line-index. Words on the same wrapped line share a
+ * delay, so a paragraph reveals line by line.
+ */
+
+/** Tags whose children are themselves blocks — we recurse instead of splitting. */
+const BLOCK_CONTAINER = new Set([
+  'DIV',
+  'UL',
+  'OL',
+  'BLOCKQUOTE',
+  'TABLE',
+  'THEAD',
+  'TBODY',
+  'TR',
+  'FIGURE',
+]);
+
+/** Tags revealed as a single unit rather than split into visual lines. */
+const WHOLE_BLOCK = new Set(['PRE', 'TABLE', 'FIGURE', 'HR']);
+
+/**
+ * Inline elements revealed as one token instead of word-by-word. Their own box
+ * carries a background (the inline-code chip), which would otherwise show empty
+ * before its text faded in — so the whole element must reveal together.
+ */
+const ATOMIC_INLINE = new Set(['CODE', 'KBD']);
+
+interface RevealContext {
+  /** Highest --line-index assigned so far (-1 before anything is revealed). */
+  line: number;
+}
+
+function cap(line: number) {
+  return Math.min(line, blogLineRevealMaxIndex);
+}
+
+function hasBlockChildren(element: Element) {
+  for (const child of element.children) {
+    if (BLOCK_CONTAINER.has(child.tagName) || /^(P|LI|H[1-6]|PRE|HR)$/.test(child.tagName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function revealWholeBlock(element: HTMLElement, ctx: RevealContext) {
+  ctx.line += 1;
+  element.classList.add('md-reveal');
+  element.style.setProperty('--line-index', String(cap(ctx.line)));
+}
+
+/**
+ * Walks a block in document order, turning it into a flat list of reveal tokens:
+ * each word becomes a .md-word span (wrapped in place, so inline markup like
+ * links/emphasis is preserved), while atomic inline elements reveal whole.
+ */
+function collectTokens(node: Node, tokens: HTMLElement[]) {
+  for (const child of Array.from(node.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const text = child.nodeValue ?? '';
+      // Leave pure-whitespace nodes untouched so spacing/wrapping stays natural.
+      if (!text.trim() || !child.parentNode) {
+        continue;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      for (const part of text.split(/(\s+)/)) {
+        if (!part) {
+          continue;
+        }
+
+        if (/^\s+$/.test(part)) {
+          fragment.appendChild(document.createTextNode(part));
+          continue;
+        }
+
+        const span = document.createElement('span');
+        span.className = 'md-word';
+        span.textContent = part;
+        fragment.appendChild(span);
+        tokens.push(span);
+      }
+
+      child.parentNode.replaceChild(fragment, child);
+      continue;
+    }
+
+    if (child.nodeType !== Node.ELEMENT_NODE) {
+      continue;
+    }
+
+    const element = child as HTMLElement;
+
+    if (ATOMIC_INLINE.has(element.tagName)) {
+      element.classList.add('md-word');
+      tokens.push(element);
+    } else {
+      collectTokens(element, tokens);
+    }
+  }
+}
+
+/** Wraps a block into reveal tokens, then groups them by visual line. */
+function splitIntoLines(block: HTMLElement, ctx: RevealContext) {
+  const words: HTMLElement[] = [];
+
+  // Native list markers can't be opacity-animated, so we suppress them (CSS) and
+  // inject our own marker as the li's first token — it reveals with the first
+  // line. CSS fills its glyph (bullet/number) via ::before.
+  if (block.tagName === 'LI') {
+    const marker = document.createElement('span');
+    marker.className = 'md-word md-marker';
+    marker.setAttribute('aria-hidden', 'true');
+    block.insertBefore(marker, block.firstChild);
+    words.push(marker);
+  }
+
+  collectTokens(block, words);
+
+  if (!words.length) {
     return;
   }
 
-  element.classList.add('md-line-reveal-host');
+  // A new visual line begins when a word sits more than half a line-height below
+  // the current line's top — small baseline shifts (inline code, sup/sub) don't
+  // count. offsetTop is a layout value, so the reveal transform doesn't skew it.
+  const computed = getComputedStyle(block);
+  const parsedLineHeight = parseFloat(computed.lineHeight);
+  const lineHeight = Number.isNaN(parsedLineHeight) ? words[0].offsetHeight || 20 : parsedLineHeight;
+  const threshold = lineHeight * 0.5;
+
+  let lineTop: number | null = null;
+
+  for (const word of words) {
+    const top = word.offsetTop;
+
+    if (lineTop === null || top > lineTop + threshold) {
+      ctx.line += 1;
+      lineTop = top;
+    }
+
+    word.style.setProperty('--line-index', String(cap(ctx.line)));
+  }
 }
 
-function canSplitLines(element: HTMLElement) {
-  if (element.tagName === 'PRE') {
-    return false;
+function process(element: HTMLElement, ctx: RevealContext) {
+  if (WHOLE_BLOCK.has(element.tagName)) {
+    revealWholeBlock(element, ctx);
+    return;
   }
 
-  if (element.querySelector('pre, img, table, ul, ol')) {
-    return false;
+  if (hasBlockChildren(element)) {
+    for (const child of Array.from(element.children)) {
+      process(child as HTMLElement, ctx);
+    }
+    return;
   }
 
-  return Boolean(element.textContent?.trim());
+  if (element.textContent && element.textContent.trim()) {
+    splitIntoLines(element, ctx);
+  } else {
+    // No text (e.g. a paragraph that only holds an image) — reveal in one go.
+    revealWholeBlock(element, ctx);
+  }
 }
 
-function wrapAsSingleLine(element: HTMLElement, lineIndex: number) {
-  if (element.dataset.lineReveal === 'true') {
-    return lineIndex + 1;
+/**
+ * Splits the article's blocks into per-line word spans tagged for CSS reveal.
+ * Returns the number of distinct reveal lines (for downstream timing).
+ */
+export function applyMarkdownLineReveal(root: HTMLElement): number {
+  const ctx: RevealContext = { line: -1 };
+
+  for (const child of Array.from(root.children)) {
+    process(child as HTMLElement, ctx);
   }
 
-  element.dataset.lineReveal = 'true';
-  tagRevealHost(element);
-
-  const line = document.createElement('div');
-  line.className = 'md-line';
-  line.style.setProperty('--line-index', String(lineIndex));
-
-  const inner = document.createElement('div');
-  inner.className = 'md-line__inner';
-
-  while (element.firstChild) {
-    inner.appendChild(element.firstChild);
-  }
-
-  line.appendChild(inner);
-  element.appendChild(line);
-
-  return lineIndex + 1;
-}
-
-function splitIntoLines(element: HTMLElement, startIndex: number) {
-  if (element.dataset.lineReveal === 'true') {
-    return startIndex;
-  }
-
-  const text = element.textContent ?? '';
-  if (!text.trim()) {
-    return startIndex;
-  }
-
-  element.dataset.lineReveal = 'true';
-  tagRevealHost(element);
-  element.textContent = '';
-
-  const tokens = text.split(/(\s+)/).filter((token) => token.length > 0);
-  const wordSpans: HTMLSpanElement[] = [];
-
-  for (const token of tokens) {
-    const span = document.createElement('span');
-    span.style.display = 'inline';
-    span.textContent = token;
-    element.appendChild(span);
-    wordSpans.push(span);
-  }
-
-  const lineGroups: HTMLSpanElement[][] = [];
-  let currentLine: HTMLSpanElement[] = [];
-  let lastTop: number | null = null;
-
-  for (const span of wordSpans) {
-    const top = span.offsetTop;
-
-    if (lastTop !== null && top > lastTop) {
-      lineGroups.push(currentLine);
-      currentLine = [];
-    }
-
-    currentLine.push(span);
-    lastTop = top;
-  }
-
-  if (currentLine.length > 0) {
-    lineGroups.push(currentLine);
-  }
-
-  element.textContent = '';
-
-  let lineIndex = startIndex;
-
-  for (const group of lineGroups) {
-    const line = document.createElement('div');
-    line.className = 'md-line';
-    line.style.setProperty('--line-index', String(lineIndex));
-
-    const inner = document.createElement('div');
-    inner.className = 'md-line__inner';
-
-    for (const span of group) {
-      inner.appendChild(span);
-    }
-
-    line.appendChild(inner);
-    element.appendChild(line);
-    lineIndex += 1;
-  }
-
-  return lineIndex;
-}
-
-/** Splits markdown article blocks into measured lines and tags them for CSS reveal. */
-export function applyMarkdownLineReveal(root: HTMLElement) {
-  const blocks = root.querySelectorAll<HTMLElement>(LINE_BLOCK_SELECTOR);
-
-  let lineIndex = 0;
-
-  for (const block of blocks) {
-    if (block.tagName !== 'PRE' && block.closest('pre')) {
-      continue;
-    }
-
-    if (block.tagName === 'BLOCKQUOTE' && block.querySelector('p, li')) {
-      continue;
-    }
-
-    if (canSplitLines(block)) {
-      lineIndex = splitIntoLines(block, lineIndex);
-    } else {
-      lineIndex = wrapAsSingleLine(block, lineIndex);
-    }
-  }
-
-  return lineIndex;
+  return ctx.line + 1;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts now reveal content with smoother line-by-line animation, including improved handling for lists and inline formatting.
  * Related posts now appear only after the main article reveal finishes, making the reading flow feel more polished.

* **Bug Fixes**
  * Improved reveal timing consistency for longer posts.
  * Removed a previously exposed markdown helper from auto-imports, reducing accidental template usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->